### PR TITLE
Support yolov5 benchmark

### DIFF
--- a/onnx2pytorch/operations/reshape.py
+++ b/onnx2pytorch/operations/reshape.py
@@ -52,6 +52,9 @@ class Reshape(Operator):
         else:
             # This raises RuntimeWarning: iterating over a tensor.
             # FIXME: this looks not right.
+            # if the first dim is batch size, manually add the batch size to the shape
+            if len(input.size())==len(shape)+1:
+                shape = torch.tensor([input.size(0)]+shape.tolist(),device=shape.device)
             shape = [x if x != 0 else input.size(i) for i, x in enumerate(shape)]
         if not self.enable_pruning:
             return torch.reshape(input, tuple(shape))

--- a/onnx2pytorch/operations/resize.py
+++ b/onnx2pytorch/operations/resize.py
@@ -44,7 +44,9 @@ class Resize(Operator):
             raise ValueError(
                 "Only one of the two, scales or sizes, needs to be defined."
             )
-
+            
+        # inside the scales, if each element is a one-element tensor, extract it to a float. 
+        scales = tuple([tmp.item() if isinstance(tmp, torch.Tensor) else tmp for tmp in scales])
         return F.interpolate(
             inp,
             scale_factor=scales,

--- a/onnx2pytorch/operations/transpose.py
+++ b/onnx2pytorch/operations/transpose.py
@@ -12,6 +12,7 @@ class Transpose(nn.Module):
             dims = tuple(reversed(range(data.dim())))
         else:
             dims = self.dims
+        # if the first dim is batch size, manually add the batch size to the shape
         if len(data.shape)==len(dims)+1:
             dims = tuple([0]+[tmp+1 for tmp in dims])
         transposed = data.permute(dims)

--- a/onnx2pytorch/operations/transpose.py
+++ b/onnx2pytorch/operations/transpose.py
@@ -12,5 +12,7 @@ class Transpose(nn.Module):
             dims = tuple(reversed(range(data.dim())))
         else:
             dims = self.dims
+        if len(data.shape)==len(dims)+1:
+            dims = tuple([0]+[tmp+1 for tmp in dims])
         transposed = data.permute(dims)
         return transposed


### PR DESCRIPTION
we fix resize.py for incorrect scale, e.g.:

before:
scale = [tensor([float]),tensor([float]),tensor([float]),tensor([float]),]
after:
scale = [float, float, float, float]

we also fix reshape.py and transpose.py for multiple batch size. 