### PR TITLE
Support legacy attribute "broadcast"

### DIFF
--- a/onnx2pytorch/convert/attribute.py
+++ b/onnx2pytorch/convert/attribute.py
@@ -182,8 +182,9 @@ def extract_attributes(node):
         elif attr.name == "value_strings":
             kwargs["constant"] = extract_attr_values(attr)
         elif attr.name == "broadcast":
-            kwargs["constant"] = extract_attr_values(attr)
-        elif node.op_type == "Resize":
+            # Broadcasting should be supported by PyTorch (and onnx since version 7) by default
+            pass
+        elif node.op_type == "Resize":  
             # These parameters are not used, warn in Resize operator
             kwargs[attr.name] = extract_attr_values(attr)
         else:

--- a/onnx2pytorch/convert/attribute.py
+++ b/onnx2pytorch/convert/attribute.py
@@ -181,6 +181,8 @@ def extract_attributes(node):
             kwargs["constant"] = extract_attr_values(attr)
         elif attr.name == "value_strings":
             kwargs["constant"] = extract_attr_values(attr)
+        elif attr.name == "broadcast":
+            kwargs["constant"] = extract_attr_values(attr)
         elif node.op_type == "Resize":
             # These parameters are not used, warn in Resize operator
             kwargs[attr.name] = extract_attr_values(attr)


### PR DESCRIPTION
Attribute "broadcast" was used in some operators (eg. Gemm, Add) [https://github.com/onnx/onnx/blob/main/docs/Changelog.md#gemm-6](https://github.com/onnx/onnx/blob/main/docs/Changelog.md#gemm-6). 
It has been removed and broadcasting has been supported by default since version 7 of the ONNX operator set [https://github.com/onnx/onnx/blob/main/docs/Changelog.md#gemm-7](https://github.com/onnx/onnx/blob/main/docs/Changelog.md#gemm-7). 
Since PyTorch also supports broadcasting automatically by default, adding this attribute to the function ```extract_attribute``` and ignoring it can avoid errors when converting old versions ONNX models.